### PR TITLE
chore: useApi hook 추가

### DIFF
--- a/packages/core-lib/src/api/hooks/useApi.ts
+++ b/packages/core-lib/src/api/hooks/useApi.ts
@@ -1,0 +1,16 @@
+import { useQuery } from 'react-query';
+import type { QueryFunction, QueryKey, UseQueryOptions } from 'react-query';
+
+type TQueryFunction<T> = QueryFunction<T, QueryKey>;
+type TOptions<T> = Omit<
+  UseQueryOptions<T, unknown, T, QueryKey>,
+  'queryKey' | 'queryFn'
+>;
+
+export const useGetApi = <T>(
+  queryKey: QueryKey, // string | unknown[]
+  queryFn: TQueryFunction<T>, // <T>() => Promise<T>
+  options?: TOptions<T>
+) => {
+  return useQuery(queryKey, queryFn, options);
+};

--- a/packages/core-lib/src/api/hooks/useApi.ts
+++ b/packages/core-lib/src/api/hooks/useApi.ts
@@ -2,10 +2,7 @@ import { useQuery } from 'react-query';
 import type { QueryFunction, QueryKey, UseQueryOptions } from 'react-query';
 
 type TQueryFunction<T> = QueryFunction<T, QueryKey>;
-type TOptions<T> = Omit<
-  UseQueryOptions<T, unknown, T, QueryKey>,
-  'queryKey' | 'queryFn'
->;
+type TOptions<T> = Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
 
 export const useGetApi = <T>(
   queryKey: QueryKey, // string | unknown[]

--- a/packages/core-lib/src/api/hooks/useCallCoin.ts
+++ b/packages/core-lib/src/api/hooks/useCallCoin.ts
@@ -1,6 +1,6 @@
-import { useQuery } from 'react-query';
 import { callGetCoinList } from '../requests/callCoin';
+import { useGetApi } from './useApi';
 
 export const useCallGetCoin = (limit: number) => {
-  return useQuery(['callGetCoinList'], () => callGetCoinList(limit));
+  return useGetApi(['callGetCoinList'], () => callGetCoinList(limit));
 };


### PR DESCRIPTION
* core-lib 의 공통으로 사용하는 react-query 훅을 래핑하는 useApi 훅 추가
  - 추 후에 react-query 의 운영상의 문제로 fetch 관련 라이브러리를 수정해야할 때 공통만 바꾸기 위함.
  - 사용법은 기존 react-query의 useQuery 와 동일합니다. (useMutation 관련도 추가 예정입니다) 