### PR TITLE
feat: antd form 사용해 회원가입 일부 구현

### DIFF
--- a/apps/nextjs-coinone-app/.eslintrc.js
+++ b/apps/nextjs-coinone-app/.eslintrc.js
@@ -38,6 +38,7 @@ module.exports = {
       },
     },
     {
+      files: ['src/backend/**/*graphql*schema*.ts'],
       rules: {
         '@typescript-eslint/naming-convention': [
           'error',

--- a/apps/nextjs-coinone-app/constants/codes.tsx
+++ b/apps/nextjs-coinone-app/constants/codes.tsx
@@ -41,3 +41,26 @@ export const PERSONAL_REGISTER_TYPE = [
     option2: '국내거주',
   },
 ];
+
+export const REGISTER_AGREE_LIST = [
+  {
+    name: 'agree1',
+    label: '코인원 이용약관',
+    link: '#',
+  },
+  {
+    name: 'agree2',
+    label: '개인정보 수집 및 이용',
+    link: '#',
+  },
+  {
+    name: 'agree3',
+    label: '고유식별정보 수집 및 이용',
+    link: '#',
+  },
+  {
+    name: 'agree4',
+    label: '고유식별정보 수집 및 이용 (선택)',
+    link: '#',
+  },
+];

--- a/apps/nextjs-coinone-app/constants/codes.tsx
+++ b/apps/nextjs-coinone-app/constants/codes.tsx
@@ -5,3 +5,39 @@ export const MAIN_CAROUSEL = [
   { title: 'REAP 신규 상장', desc: '신규 상장' },
   { title: 'BTR 신규 상장', desc: '신규 상장' },
 ];
+
+export const CORPORATE_REGISTER_TYPE = [
+  {
+    name: 'corporate_1',
+    label: '법인',
+    option1: '해외법인',
+    option2: '국내법인',
+  },
+  {
+    name: 'corporate_2',
+    label: '대표자 국적',
+    option1: '외국인',
+    option2: '내국인',
+  },
+  {
+    name: 'corporate_3',
+    label: '대표자 거주 여부',
+    option1: '해외거주',
+    option2: '국내거주',
+  },
+];
+
+export const PERSONAL_REGISTER_TYPE = [
+  {
+    name: 'personal_1',
+    label: '국적',
+    option1: '외국인',
+    option2: '내국인',
+  },
+  {
+    name: 'personal_2',
+    label: '거주 여부',
+    option1: '해외거주',
+    option2: '국내거주',
+  },
+];

--- a/apps/nextjs-coinone-app/lint-staged.config.js
+++ b/apps/nextjs-coinone-app/lint-staged.config.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+/**
+ * This files overrides the base lint-staged.config.js present in the root directory.
+ * It allows to run eslint based the package specific requirements.
+ * {@link https://github.com/okonet/lint-staged#how-to-use-lint-staged-in-a-multi-package-monorepo}
+ * {@link https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-lint-staged.md}
+ */
+
+const {
+  concatFilesForPrettier,
+  getEslintFixCmd,
+} = require('../../lint-staged.common.js');
+
+/**
+ * @type {Record<string, (filenames: string[]) => string | string[] | Promise<string | string[]>>}
+ */
+const rules = {
+  '**/*.{js,jsx,ts,tsx}': (filenames) => {
+    return getEslintFixCmd({
+      cwd: __dirname,
+      fix: true,
+      cache: true,
+      // when autofixing staged-files a good tip is to disable react-hooks/exhaustive-deps, cause
+      // a change here can potentially break things without proper visibility.
+      rules: ['react-hooks/exhaustive-deps: off'],
+      maxWarnings: 25,
+      files: filenames,
+    });
+  },
+  '**/*.{json,md,mdx,css,html,yml,yaml,scss}': (filenames) => {
+    return [`prettier --write ${concatFilesForPrettier(filenames)}`];
+  },
+};
+
+module.exports = rules;

--- a/apps/nextjs-coinone-app/package.json
+++ b/apps/nextjs-coinone-app/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@ant-design/icons": "4.7.0",
     "@emotion/react": "11.9.3",
     "@types/axios": "0.14.0",
     "antd": "4.21.2",

--- a/apps/nextjs-coinone-app/package.json
+++ b/apps/nextjs-coinone-app/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "test": "yarn test-unit",
+    "test-unit": "echo 'Not yet Test'",
+    "typecheck": "tsc --project ./tsconfig.json --noEmit",
+    "lint": "eslint . --ext .ts,.tsx,.js,.jsx,.cjs,.mjs,.mdx,.graphql --cache --cache-location ../../.cache/eslint/nextjs-app.eslintcache",
+    "fix-all-files": "eslint . --ext .ts,.tsx,.js,.jsx,.cjs,.mjs,.mdx,.graphql --fix"
   },
   "dependencies": {
     "@ant-design/icons": "4.7.0",

--- a/apps/nextjs-coinone-app/pages/register/index.tsx
+++ b/apps/nextjs-coinone-app/pages/register/index.tsx
@@ -1,5 +1,5 @@
 /* components */
-import Index from 'containers/Register/index';
+import Index from 'containers/Register';
 
 export default function index() {
   return <Index />;

--- a/apps/nextjs-coinone-app/pages/register/index.tsx
+++ b/apps/nextjs-coinone-app/pages/register/index.tsx
@@ -1,0 +1,6 @@
+/* components */
+import Index from 'containers/Register/index';
+
+export default function index() {
+  return <Index />;
+}

--- a/apps/nextjs-coinone-app/src/Interface/Register.ts
+++ b/apps/nextjs-coinone-app/src/Interface/Register.ts
@@ -1,3 +1,10 @@
 export interface IProps {
   setTitle: (value: string) => void;
 }
+
+export interface IRegisterList {
+  name: string;
+  label: string;
+  option1: string;
+  option2: string;
+}

--- a/apps/nextjs-coinone-app/src/Interface/Register.ts
+++ b/apps/nextjs-coinone-app/src/Interface/Register.ts
@@ -1,0 +1,3 @@
+export interface IProps {
+  setTitle: (value: string) => void;
+}

--- a/apps/nextjs-coinone-app/src/components/Button/index.tsx
+++ b/apps/nextjs-coinone-app/src/components/Button/index.tsx
@@ -1,11 +1,8 @@
 /* next */
 import type { FC } from 'react';
 
-/* style */
-import { smallGrayButton } from './Button.style';
-
 interface Iprops {
-  text: String;
+  text: string;
 }
 
 export const Button: FC<Iprops> = ({ text }) => {

--- a/apps/nextjs-coinone-app/src/containers/Main/Main.style.jsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/Main.style.jsx
@@ -1,10 +1,5 @@
 import { css } from '@emotion/react';
 
-export const cssMainContent = css`
-  margin: 50px auto;
-  max-width: 1024px;
-`;
-
 export const cssMainCarouselText = css`
   display: flex;
   align-items: center;

--- a/apps/nextjs-coinone-app/src/containers/Main/MainCarousel.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/MainCarousel.tsx
@@ -1,5 +1,5 @@
 /* next */
-import { FC } from 'react';
+import type { FC } from 'react';
 import Image from 'next/image';
 
 /* codes */

--- a/apps/nextjs-coinone-app/src/containers/Main/MainCarouselText.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/MainCarouselText.tsx
@@ -1,5 +1,6 @@
 /* next */
-import { FC, useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 /* components */
 import { MainCarousel } from './MainCarousel';

--- a/apps/nextjs-coinone-app/src/containers/Main/MainRank.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/MainRank.tsx
@@ -12,8 +12,8 @@ import { useCallGetCoin } from '@sb/core-lib/api/hooks/useCallCoin';
 /* style */
 import { cssMainRankTitle, cssMainRankTable } from './Main.style';
 
-/*type */
-import { ICoin } from '@sb/core-lib/interface/Coin';
+/* type */
+import type { ICoin } from '@sb/core-lib/interface/Coin';
 
 const columns: ColumnsType<ICoin> = [
   {

--- a/apps/nextjs-coinone-app/src/containers/Main/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/index.tsx
@@ -6,15 +6,15 @@ import { MainCarouselText } from './MainCarouselText';
 import { MainRank } from './MainRank';
 
 /* style */
-import { cssMainContent } from './Main.style';
+import { ContentWrap } from '../../style/common';
 
 export const Main: FC = () => {
   return (
     <>
       <MainCarouselText />
-      <section css={cssMainContent}>
+      <ContentWrap>
         <MainRank />
-      </section>
+      </ContentWrap>
     </>
   );
 };

--- a/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export const RegisterContentWrap = styled.section`
+  margin: 50px auto;
+  max-width: 480px;
+  .ant-form-item {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .ant-form-item-control {
+      width: 100%;
+      .ant-form-item-control-input {
+        margin-bottom: 5px;
+      }
+      .ant-form-item-explain {
+        margin-bottom: 15px;
+      }
+    }
+
+    .ant-radio-group {
+      display: flex;
+      gap: 10px;
+      label {
+        flex: auto;
+      }
+      .ant-radio-button-wrapper {
+        text-align: center;
+        padding: 10px;
+        height: max-content;
+        border-radius: 8px;
+        border-left-width: 1px;
+        &:not(:first-child)::before {
+          background-color: #fff0;
+        }
+      }
+    }
+    .ant-input {
+      height: 50px;
+      border-radius: 7px;
+    }
+  }
+`;
+
+export const RegisterCheckBoxWrap = styled.div`
+  .ant-form-item {
+    flex-direction: column;
+  }
+`;
+
+export const cssRegisterTitle = css`
+  margin-bottom: 32px;
+  font-size: 24px;
+  font-weight: 700;
+`;

--- a/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
@@ -40,6 +40,15 @@ export const RegisterContentWrap = styled.section`
       border-radius: 7px;
     }
   }
+
+  @keyframes showanimation {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
 `;
 
 export const RegisterCheckBoxWrap = styled.div`

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -1,24 +1,25 @@
+/* utils */
+import FORM_RULES from '@sb/core-lib/utils/form-rules';
+
+/* lib */
+import { Button, Form, Input, Radio } from 'antd';
+import type { Rule } from 'antd/lib/form';
+
 /* next */
 import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
-/* lib */
-import { Button, Form, Input, Radio } from 'antd';
-
 /* constans */
-import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import {
   CORPORATE_REGISTER_TYPE,
   PERSONAL_REGISTER_TYPE,
 } from '../../../constants/codes';
 
-/* style */
-import { MaxButton } from '../../style/common';
-
 /* types */
 import type { IProps, IRegisterList } from '../../Interface/Register';
-import type { Rule } from 'antd/lib/form';
 
+/* style */
+import { MaxButton } from '../../style/common';
 const Register01: FC<IProps> = (props) => {
   const form = Form.useFormInstance();
   const userType = Form.useWatch('user-type', form);
@@ -63,20 +64,22 @@ const Register01: FC<IProps> = (props) => {
           <Radio.Button value="개인">개인</Radio.Button>
         </Radio.Group>
       </Form.Item>
-      {userTypeList.map((type) => (
-        <Form.Item
-          key={type.label}
-          label={type.label}
-          name={type.name}
-          colon={false}
-          rules={FORM_RULES.defaultrule}
-        >
-          <Radio.Group>
-            <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
-            <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
-          </Radio.Group>
-        </Form.Item>
-      ))}
+      {userType &&
+        userTypeList.map((type) => (
+          <Form.Item
+            key={type.label}
+            label={type.label}
+            name={type.name}
+            colon={false}
+            rules={FORM_RULES.defaultrule}
+            style={{ animation: 'showanimation 450ms ease-in-out' }}
+          >
+            <Radio.Group>
+              <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
+              <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+        ))}
 
       <Form.Item>
         <MaxButton>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -1,0 +1,123 @@
+/* next */
+import { FC, useState } from 'react';
+
+/* lib */
+import { Button, Form, Input, Radio } from 'antd';
+
+/* constans */
+import FORM_RULES from '@sb/core-lib/utils/formRules';
+import {
+  CORPORATE_REGISTER_TYPE,
+  PERSONAL_REGISTER_TYPE,
+} from '../../../constants/codes';
+
+/* style */
+import { cssRegisterTitle } from './Register.style';
+import { MaxButton } from '../../style/common';
+
+const Register01: FC = () => {
+  const [form] = Form.useForm();
+  const [type, setType] = useState('');
+
+  const onFinish = (values: any) => {
+    console.log('Success:', values);
+  };
+
+  const onFinishFailed = (errorInfo: any) => {
+    console.log('Failed:', errorInfo);
+  };
+
+  const onFieldsChangeType = (value: any) => {
+    if (value[0].name.includes('user-type')) {
+      setType(value[0].value);
+
+      // clear inputs
+      const typeArr =
+        type === '법인' ? PERSONAL_REGISTER_TYPE : CORPORATE_REGISTER_TYPE;
+      const clearTypes = typeArr.reduce(
+        (acc, current) => ({ ...acc, [current.name]: '' }),
+        {}
+      );
+      form.setFieldsValue({ ...clearTypes });
+    }
+  };
+
+  return (
+    <>
+      <div css={cssRegisterTitle}>
+        본인인증을 시작합니다. <br />
+        예상 소요시간은 10분입니다.
+      </div>
+      <Form
+        form={form}
+        name="basic"
+        initialValues={{ remember: true }}
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
+        onFieldsChange={onFieldsChangeType}
+        autoComplete="off"
+      >
+        <Form.Item
+          label="유저 이름"
+          colon={false}
+          name="username"
+          rules={FORM_RULES.userNameRule as any}
+        >
+          <Input />
+        </Form.Item>
+
+        <Form.Item
+          name="user-type"
+          colon={false}
+          label="가입유형"
+          rules={FORM_RULES.defaultRequireRule}
+        >
+          <Radio.Group>
+            <Radio.Button value="법인">법인</Radio.Button>
+            <Radio.Button value="개인">개인</Radio.Button>
+          </Radio.Group>
+        </Form.Item>
+        {type === '법인' &&
+          CORPORATE_REGISTER_TYPE.map((type) => (
+            <Form.Item
+              key={type.label}
+              label={type.label}
+              name={type.name}
+              colon={false}
+              rules={FORM_RULES.defaultRequireRule}
+            >
+              <Radio.Group>
+                <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
+                <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
+              </Radio.Group>
+            </Form.Item>
+          ))}
+        {type === '개인' &&
+          PERSONAL_REGISTER_TYPE.map((type) => (
+            <Form.Item
+              key={type.label}
+              label={type.label}
+              name={type.name}
+              colon={false}
+              rules={FORM_RULES.defaultRequireRule}
+            >
+              <Radio.Group>
+                <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
+                <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
+              </Radio.Group>
+            </Form.Item>
+          ))}
+
+        <Form.Item>
+          <MaxButton>
+            <Button type="primary" htmlType="submit">
+              이동
+            </Button>
+          </MaxButton>
+        </Form.Item>
+      </Form>
+    </>
+  );
+};
+
+export default Register01;

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -14,11 +14,10 @@ import {
 /* style */
 import { MaxButton } from '../../style/common';
 
-interface Iprops {
-  setTitle: (value: string) => void;
-}
+/* types */
+import { IProps } from '../../Interface/Register';
 
-const Register01: FC<Iprops> = (props: Iprops) => {
+const Register01: FC<IProps> = (props: IProps) => {
   const form = Form.useFormInstance();
   const userType = Form.useWatch('user-type', form);
 

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -5,7 +5,7 @@ import { FC, useEffect } from 'react';
 import { Button, Form, Input, Radio } from 'antd';
 
 /* constans */
-import FORM_RULES from '@sb/core-lib/utils/formRules';
+import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import {
   CORPORATE_REGISTER_TYPE,
   PERSONAL_REGISTER_TYPE,
@@ -43,7 +43,7 @@ const Register01: FC<IProps> = (props) => {
         label="유저 이름"
         colon={false}
         name="username"
-        rules={FORM_RULES.userNameRule as Rule[]}
+        rules={FORM_RULES.usenamerule as Rule[]}
       >
         <Input />
       </Form.Item>
@@ -52,7 +52,7 @@ const Register01: FC<IProps> = (props) => {
         name="user-type"
         colon={false}
         label="가입유형"
-        rules={FORM_RULES.defaultRequireRule}
+        rules={FORM_RULES.defaultrule}
       >
         <Radio.Group>
           <Radio.Button value="법인">법인</Radio.Button>
@@ -66,7 +66,7 @@ const Register01: FC<IProps> = (props) => {
             label={type.label}
             name={type.name}
             colon={false}
-            rules={FORM_RULES.defaultRequireRule}
+            rules={FORM_RULES.defaultrule}
           >
             <Radio.Group>
               <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
@@ -81,7 +81,7 @@ const Register01: FC<IProps> = (props) => {
             label={type.label}
             name={type.name}
             colon={false}
-            rules={FORM_RULES.defaultRequireRule}
+            rules={FORM_RULES.defaultrule}
           >
             <Radio.Group>
               <Radio.Button value={type.option1}>{type.option1}</Radio.Button>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -1,5 +1,6 @@
 /* next */
-import { FC, useEffect, useState } from 'react';
+import type { FC } from 'react';
+import { useEffect, useState } from 'react';
 
 /* lib */
 import { Button, Form, Input, Radio } from 'antd';
@@ -15,8 +16,8 @@ import {
 import { MaxButton } from '../../style/common';
 
 /* types */
-import { IProps, IRegisterList } from '../../Interface/Register';
-import { Rule } from 'antd/lib/form';
+import type { IProps, IRegisterList } from '../../Interface/Register';
+import type { Rule } from 'antd/lib/form';
 
 const Register01: FC<IProps> = (props) => {
   const form = Form.useFormInstance();

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -1,5 +1,5 @@
 /* next */
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 
 /* lib */
 import { Button, Form, Input, Radio } from 'antd';
@@ -15,12 +15,13 @@ import {
 import { MaxButton } from '../../style/common';
 
 /* types */
-import { IProps } from '../../Interface/Register';
+import { IProps, IRegisterList } from '../../Interface/Register';
 import { Rule } from 'antd/lib/form';
 
 const Register01: FC<IProps> = (props) => {
   const form = Form.useFormInstance();
   const userType = Form.useWatch('user-type', form);
+  const [userTypeList, setUserTypeList] = useState<IRegisterList[]>([]);
 
   useEffect(() => {
     // clear inputs
@@ -30,6 +31,8 @@ const Register01: FC<IProps> = (props) => {
       (acc, current) => ({ ...acc, [current.name]: '' }),
       {}
     );
+    // set user type list
+    setUserTypeList(typeArr);
     form.setFieldsValue({ ...clearTypes });
   }, [userType]);
 
@@ -59,36 +62,20 @@ const Register01: FC<IProps> = (props) => {
           <Radio.Button value="개인">개인</Radio.Button>
         </Radio.Group>
       </Form.Item>
-      {userType === '법인' &&
-        CORPORATE_REGISTER_TYPE.map((type) => (
-          <Form.Item
-            key={type.label}
-            label={type.label}
-            name={type.name}
-            colon={false}
-            rules={FORM_RULES.defaultrule}
-          >
-            <Radio.Group>
-              <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
-              <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
-            </Radio.Group>
-          </Form.Item>
-        ))}
-      {userType === '개인' &&
-        PERSONAL_REGISTER_TYPE.map((type) => (
-          <Form.Item
-            key={type.label}
-            label={type.label}
-            name={type.name}
-            colon={false}
-            rules={FORM_RULES.defaultrule}
-          >
-            <Radio.Group>
-              <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
-              <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
-            </Radio.Group>
-          </Form.Item>
-        ))}
+      {userTypeList.map((type) => (
+        <Form.Item
+          key={type.label}
+          label={type.label}
+          name={type.name}
+          colon={false}
+          rules={FORM_RULES.defaultrule}
+        >
+          <Radio.Group>
+            <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
+            <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
+          </Radio.Group>
+        </Form.Item>
+      ))}
 
       <Form.Item>
         <MaxButton>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -14,7 +14,11 @@ import {
 /* style */
 import { MaxButton } from '../../style/common';
 
-const Register01: FC = () => {
+interface Iprops {
+  setTitle: (value: string) => void;
+}
+
+const Register01: FC<Iprops> = (props: Iprops) => {
   const form = Form.useFormInstance();
   const userType = Form.useWatch('user-type', form);
 
@@ -28,6 +32,10 @@ const Register01: FC = () => {
     );
     form.setFieldsValue({ ...clearTypes });
   }, [userType]);
+
+  useEffect(() => {
+    props.setTitle('본인인증을 시작합니다.<br />예상 소요시간은 10분입니다.');
+  }, []);
 
   return (
     <>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -1,5 +1,5 @@
 /* next */
-import { FC, useState } from 'react';
+import { FC, useEffect } from 'react';
 
 /* lib */
 import { Button, Form, Input, Radio } from 'antd';
@@ -12,110 +12,83 @@ import {
 } from '../../../constants/codes';
 
 /* style */
-import { cssRegisterTitle } from './Register.style';
 import { MaxButton } from '../../style/common';
 
 const Register01: FC = () => {
-  const [form] = Form.useForm();
-  const [type, setType] = useState('');
+  const form = Form.useFormInstance();
+  const userType = Form.useWatch('user-type', form);
 
-  const onFinish = (values: any) => {
-    console.log('Success:', values);
-  };
-
-  const onFinishFailed = (errorInfo: any) => {
-    console.log('Failed:', errorInfo);
-  };
-
-  const onFieldsChangeType = (value: any) => {
-    if (value[0].name.includes('user-type')) {
-      setType(value[0].value);
-
-      // clear inputs
-      const typeArr =
-        type === '법인' ? PERSONAL_REGISTER_TYPE : CORPORATE_REGISTER_TYPE;
-      const clearTypes = typeArr.reduce(
-        (acc, current) => ({ ...acc, [current.name]: '' }),
-        {}
-      );
-      form.setFieldsValue({ ...clearTypes });
-    }
-  };
+  useEffect(() => {
+    // clear inputs
+    const typeArr =
+      userType === '법인' ? PERSONAL_REGISTER_TYPE : CORPORATE_REGISTER_TYPE;
+    const clearTypes = typeArr.reduce(
+      (acc, current) => ({ ...acc, [current.name]: '' }),
+      {}
+    );
+    form.setFieldsValue({ ...clearTypes });
+  }, [userType]);
 
   return (
     <>
-      <div css={cssRegisterTitle}>
-        본인인증을 시작합니다. <br />
-        예상 소요시간은 10분입니다.
-      </div>
-      <Form
-        form={form}
-        name="basic"
-        initialValues={{ remember: true }}
-        onFinish={onFinish}
-        onFinishFailed={onFinishFailed}
-        onFieldsChange={onFieldsChangeType}
-        autoComplete="off"
+      <Form.Item
+        label="유저 이름"
+        colon={false}
+        name="username"
+        rules={FORM_RULES.userNameRule as any}
       >
-        <Form.Item
-          label="유저 이름"
-          colon={false}
-          name="username"
-          rules={FORM_RULES.userNameRule as any}
-        >
-          <Input />
-        </Form.Item>
+        <Input />
+      </Form.Item>
 
-        <Form.Item
-          name="user-type"
-          colon={false}
-          label="가입유형"
-          rules={FORM_RULES.defaultRequireRule}
-        >
-          <Radio.Group>
-            <Radio.Button value="법인">법인</Radio.Button>
-            <Radio.Button value="개인">개인</Radio.Button>
-          </Radio.Group>
-        </Form.Item>
-        {type === '법인' &&
-          CORPORATE_REGISTER_TYPE.map((type) => (
-            <Form.Item
-              key={type.label}
-              label={type.label}
-              name={type.name}
-              colon={false}
-              rules={FORM_RULES.defaultRequireRule}
-            >
-              <Radio.Group>
-                <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
-                <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-          ))}
-        {type === '개인' &&
-          PERSONAL_REGISTER_TYPE.map((type) => (
-            <Form.Item
-              key={type.label}
-              label={type.label}
-              name={type.name}
-              colon={false}
-              rules={FORM_RULES.defaultRequireRule}
-            >
-              <Radio.Group>
-                <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
-                <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
-              </Radio.Group>
-            </Form.Item>
-          ))}
+      <Form.Item
+        name="user-type"
+        colon={false}
+        label="가입유형"
+        rules={FORM_RULES.defaultRequireRule}
+      >
+        <Radio.Group>
+          <Radio.Button value="법인">법인</Radio.Button>
+          <Radio.Button value="개인">개인</Radio.Button>
+        </Radio.Group>
+      </Form.Item>
+      {userType === '법인' &&
+        CORPORATE_REGISTER_TYPE.map((type) => (
+          <Form.Item
+            key={type.label}
+            label={type.label}
+            name={type.name}
+            colon={false}
+            rules={FORM_RULES.defaultRequireRule}
+          >
+            <Radio.Group>
+              <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
+              <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+        ))}
+      {userType === '개인' &&
+        PERSONAL_REGISTER_TYPE.map((type) => (
+          <Form.Item
+            key={type.label}
+            label={type.label}
+            name={type.name}
+            colon={false}
+            rules={FORM_RULES.defaultRequireRule}
+          >
+            <Radio.Group>
+              <Radio.Button value={type.option1}>{type.option1}</Radio.Button>
+              <Radio.Button value={type.option2}>{type.option2}</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
+        ))}
 
-        <Form.Item>
-          <MaxButton>
-            <Button type="primary" htmlType="submit">
-              이동
-            </Button>
-          </MaxButton>
-        </Form.Item>
-      </Form>
+      <Form.Item>
+        <MaxButton>
+          <Button type="primary" htmlType="submit">
+            이동
+          </Button>
+        </MaxButton>
+      </Form.Item>
     </>
   );
 };

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -16,8 +16,9 @@ import { MaxButton } from '../../style/common';
 
 /* types */
 import { IProps } from '../../Interface/Register';
+import { Rule } from 'antd/lib/form';
 
-const Register01: FC<IProps> = (props: IProps) => {
+const Register01: FC<IProps> = (props) => {
   const form = Form.useFormInstance();
   const userType = Form.useWatch('user-type', form);
 
@@ -42,7 +43,7 @@ const Register01: FC<IProps> = (props: IProps) => {
         label="유저 이름"
         colon={false}
         name="username"
-        rules={FORM_RULES.userNameRule as any}
+        rules={FORM_RULES.userNameRule as Rule[]}
       >
         <Input />
       </Form.Item>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -1,0 +1,73 @@
+/* next */
+import { FC, useState, useEffect } from 'react';
+
+/* lib */
+import { Checkbox, Form, Button } from 'antd';
+import { CheckOutlined } from '@ant-design/icons';
+
+/* constans */
+import FORM_RULES from '@sb/core-lib/utils/formRules';
+import { REGISTER_AGREE_LIST } from '../../../constants/codes';
+
+/* style */
+import { MaxButton, FlexBetweenBox, LineBox } from '../../style/common';
+
+/* types */
+import { IProps } from '../../Interface/Register';
+
+const Register02: FC<IProps> = (props: IProps) => {
+  const [form] = Form.useForm();
+  const [allAgree, setAllAgree] = useState(false);
+
+  const changeAllAgree = () => {
+    setAllAgree(!allAgree);
+    const clearTypes = REGISTER_AGREE_LIST.reduce(
+      (acc, current) => ({ ...acc, [current.name]: !allAgree }),
+      {}
+    );
+    form.setFieldsValue({ ...clearTypes });
+  };
+
+  useEffect(() => {
+    props.setTitle('약관에 동의해 주세요.');
+  }, []);
+
+  return (
+    <>
+      <LineBox
+        onClick={changeAllAgree}
+        css={allAgree && { borderColor: '#1772f8' }}
+      >
+        <CheckOutlined
+          style={allAgree ? { color: '#1772f8' } : { color: '#000' }}
+        />
+        <b>모든 항목에 동의하기</b>
+      </LineBox>
+      {REGISTER_AGREE_LIST.map((agree) => (
+        <Form.Item
+          shouldUpdate
+          key={agree.name}
+          name={agree.name}
+          valuePropName="checked"
+          rules={
+            agree.name !== 'agree4' ? FORM_RULES.defaultRequireRule : undefined
+          }
+        >
+          <FlexBetweenBox>
+            <Checkbox>{agree.label}</Checkbox>
+            <u>보기</u>
+          </FlexBetweenBox>
+        </Form.Item>
+      ))}
+      <Form.Item>
+        <MaxButton>
+          <Button type="primary" htmlType="submit">
+            이동
+          </Button>
+        </MaxButton>
+      </Form.Item>
+    </>
+  );
+};
+
+export default Register02;

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -6,7 +6,7 @@ import { Checkbox, Form, Button } from 'antd';
 import { CheckOutlined } from '@ant-design/icons';
 
 /* constans */
-import FORM_RULES from '@sb/core-lib/utils/formRules';
+import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 
 /* style */
@@ -49,9 +49,7 @@ const Register02: FC<IProps> = (props: IProps) => {
           key={agree.name}
           name={agree.name}
           valuePropName="checked"
-          rules={
-            agree.name !== 'agree4' ? FORM_RULES.defaultRequireRule : undefined
-          }
+          rules={agree.name !== 'agree4' ? FORM_RULES.defaultrule : undefined}
         >
           <FlexBetweenBox>
             <Checkbox>{agree.label}</Checkbox>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -1,5 +1,6 @@
 /* next */
-import { FC, useState, useEffect } from 'react';
+import type { FC } from 'react';
+import { useState, useEffect } from 'react';
 
 /* lib */
 import { Checkbox, Form, Button } from 'antd';
@@ -13,7 +14,7 @@ import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 import { MaxButton, FlexBetweenBox, LineBox } from '../../style/common';
 
 /* types */
-import { IProps } from '../../Interface/Register';
+import type { IProps } from '../../Interface/Register';
 
 const Register02: FC<IProps> = (props: IProps) => {
   const [form] = Form.useForm();

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -1,0 +1,18 @@
+/* next */
+import { FC } from 'react';
+
+/* components */
+import Register01 from './Register01';
+
+/* style */
+import { RegisterContentWrap } from './Register.style';
+
+const Index: FC = () => {
+  return (
+    <RegisterContentWrap>
+      <Register01 />
+    </RegisterContentWrap>
+  );
+};
+
+export default Index;

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -1,5 +1,5 @@
 /* next */
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 /* components */
 import Register01 from './Register01';
@@ -12,6 +12,7 @@ import { cssRegisterTitle, RegisterContentWrap } from './Register.style';
 
 const Index: FC = () => {
   const [form] = Form.useForm();
+  const [title, setTitle] = useState('');
 
   const onFinish = (values: any) => {
     console.log('Success:', values);
@@ -24,8 +25,7 @@ const Index: FC = () => {
   return (
     <RegisterContentWrap>
       <div css={cssRegisterTitle}>
-        본인인증을 시작합니다. <br />
-        예상 소요시간은 10분입니다.
+        <div dangerouslySetInnerHTML={{ __html: title }}></div>
       </div>
       <Form
         form={form}
@@ -35,7 +35,7 @@ const Index: FC = () => {
         onFinishFailed={onFinishFailed}
         autoComplete="off"
       >
-        <Register01 />
+        <Register01 setTitle={(value: string) => setTitle(value)} />
       </Form>
     </RegisterContentWrap>
   );

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -4,13 +4,39 @@ import { FC } from 'react';
 /* components */
 import Register01 from './Register01';
 
+/* lib */
+import { Form } from 'antd';
+
 /* style */
-import { RegisterContentWrap } from './Register.style';
+import { cssRegisterTitle, RegisterContentWrap } from './Register.style';
 
 const Index: FC = () => {
+  const [form] = Form.useForm();
+
+  const onFinish = (values: any) => {
+    console.log('Success:', values);
+  };
+
+  const onFinishFailed = (errorInfo: any) => {
+    console.log('Failed:', errorInfo);
+  };
+
   return (
     <RegisterContentWrap>
-      <Register01 />
+      <div css={cssRegisterTitle}>
+        본인인증을 시작합니다. <br />
+        예상 소요시간은 10분입니다.
+      </div>
+      <Form
+        form={form}
+        name="basic"
+        initialValues={{ remember: true }}
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
+        autoComplete="off"
+      >
+        <Register01 />
+      </Form>
     </RegisterContentWrap>
   );
 };

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -1,5 +1,6 @@
 /* next */
-import { FC, useState } from 'react';
+import type { FC } from 'react';
+import { useState } from 'react';
 
 /* components */
 import Register01 from './Register01';

--- a/apps/nextjs-coinone-app/src/style/common.tsx
+++ b/apps/nextjs-coinone-app/src/style/common.tsx
@@ -1,6 +1,41 @@
 import styled from '@emotion/styled';
 
+/* SECTION */
 export const ContentWrap = styled.section`
   margin: 50px auto;
   max-width: 1024px;
+`;
+
+/* BOX CONTENT */
+export const LineBox = styled.div`
+  border: 1px solid #e4e5e8;
+  border-radius: 8px;
+  transition: border-color 0.25s;
+  display: flex;
+  align-items: center;
+  position: relative;
+  min-height: 56px;
+  padding: 20px;
+  margin-bottom: 32px;
+  gap: 10px;
+  cursor: pointer;
+`;
+
+/* BUTTON */
+export const MaxButton = styled.div`
+  button {
+    width: 100%;
+    height: 55px;
+    padding: 0;
+    line-height: 55px;
+    font-weight: 700;
+    border-radius: 8px;
+  }
+`;
+
+/* FLEX BOX STYLE */
+export const FlexBetweenBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 `;

--- a/apps/nextjs-coinone-app/src/style/common.tsx
+++ b/apps/nextjs-coinone-app/src/style/common.tsx
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+export const ContentWrap = styled.section`
+  margin: 50px auto;
+  max-width: 1024px;
+`;

--- a/packages/core-lib/src/utils/form-rules.ts
+++ b/packages/core-lib/src/utils/form-rules.ts
@@ -8,13 +8,13 @@ interface Irule {
 }
 
 export default {
-  defaultRequireRule: [
+  defaultrule: [
     {
       required: true,
       message: '필수값입니다.',
     },
   ],
-  userNameRule: [
+  usenamerule: [
     {
       required: true,
       message: '유저 이름은 필수값입니다. 2자 이상 입력해주세요',

--- a/packages/core-lib/src/utils/formRules.tsx
+++ b/packages/core-lib/src/utils/formRules.tsx
@@ -1,0 +1,28 @@
+interface Irule {
+  field: string;
+  fullField: string;
+  message: string;
+  required: true;
+  type: string;
+  validator: () => void;
+}
+
+export default {
+  defaultRequireRule: [
+    {
+      required: true,
+      message: '필수값입니다.',
+    },
+  ],
+  userNameRule: [
+    {
+      required: true,
+      message: '유저 이름은 필수값입니다. 2자 이상 입력해주세요',
+      validator: async (rule: Irule, value: string) => {
+        if (value.length < 2) {
+          throw new Error('Something wrong!');
+        }
+      },
+    },
+  ],
+};

--- a/packages/core-lib/src/utils/formRules.tsx
+++ b/packages/core-lib/src/utils/formRules.tsx
@@ -1,10 +1,10 @@
 interface Irule {
-  field: string;
-  fullField: string;
-  message: string;
-  required: true;
-  type: string;
-  validator: () => void;
+  field?: string;
+  fullField?: string;
+  message?: string;
+  required?: true;
+  type?: string;
+  validator?: () => void;
 }
 
 export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3513,6 +3513,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "coinone@workspace:apps/nextjs-coinone-app"
   dependencies:
+    "@ant-design/icons": 4.7.0
     "@emotion/react": 11.9.3
     "@types/axios": 0.14.0
     "@types/node": 18.0.0


### PR DESCRIPTION
- antd form 사용해 회원가입 일부 (2단계 구현) 했습니다.
- custom formRules사용해 form 유효성 검사하는 부분 root에 추가해두었습니다.
- 하나의 form에 여러 컴포넌트에서 변경, 접근하도록 구현했습니다.

**(이후 구현하려고 하는 부분)**
한개의 상위 컴포넌트에서 form 전송하도록 하고, 
여러 스텝(페이지) 구현된 하위 여러개 컴포넌트에서 입력받아 상위로 넘기도록 구현하려고 합니다.
   이를 위해 recoil 사용해 값 검증되면 count해서 이동 시킬지,
   router에 query 추가해서 페이지 넘어가게 할지 고민중입니다.
해당 브런치 merge 되면 두 가지 방법중에 하나 적용해서 다음 브런치에 추가해보려고합니다!