### PR TITLE
chore: 린트 설정 변경

### DIFF
--- a/packages/core-lib/.eslintrc.js
+++ b/packages/core-lib/.eslintrc.js
@@ -32,5 +32,21 @@ module.exports = {
         'react/display-name': 'off',
       },
     },
+    {
+      files: ['**/api/request.ts'],
+      rules: {
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: ['objectLiteralProperty'],
+            format: ['camelCase'],
+            filter: {
+              regex: '^([a-zA-Z][a-z0-9]*)(-[a-zA-Z0-9]+)*$',
+              match: false,
+            },
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/eslint-config-bases/src/bases/typescript.js
+++ b/packages/eslint-config-bases/src/bases/typescript.js
@@ -124,16 +124,6 @@ module.exports = {
       },
       {
         selector: 'objectLiteralProperty',
-        format: null,
-        leadingUnderscore: 'allowSingleOrDouble',
-        trailingUnderscore: 'allowSingleOrDouble',
-        custom: {
-          regex: '^([a-zA-Z][a-z0-9]*)(-[a-zA-Z0-9]+)*$',
-          match: true,
-        },
-      },
-      {
-        selector: 'objectLiteralProperty',
         format: [
           'camelCase',
           // Some external libraries use snake_case for params


### PR DESCRIPTION
* objectLiteralProperty 중복 사용으로 인해 린트 체크가 안되서 해당 내용 공통에서 제외
* core-lib 내의 특정 파일만 kebab-case 적용되도록 수정 (ex: content-type )