### PR TITLE
feat: use recoil to register

### DIFF
--- a/apps/nextjs-coinone-app/constants/codes.tsx
+++ b/apps/nextjs-coinone-app/constants/codes.tsx
@@ -64,3 +64,8 @@ export const REGISTER_AGREE_LIST = [
     link: '#',
   },
 ];
+
+export const REGISTER_TITLE: { [key: string]: string } = {
+  step1: '본인인증을 시작합니다.<br />예상 소요시간은 10분입니다.',
+  step2: '약관에 동의해 주세요.',
+};

--- a/apps/nextjs-coinone-app/package.json
+++ b/apps/nextjs-coinone-app/package.json
@@ -22,7 +22,8 @@
     "next-seo": "5.4.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-query": "3.39.1"
+    "react-query": "3.39.1",
+    "recoil": "0.7.4"
   },
   "devDependencies": {
     "@types/node": "18.0.0",

--- a/apps/nextjs-coinone-app/pages/_app.tsx
+++ b/apps/nextjs-coinone-app/pages/_app.tsx
@@ -1,18 +1,18 @@
+import { DefaultSeo } from 'next-seo';
+
 /* next, react */
 import type { AppProps } from 'next/app';
 import { useState } from 'react';
 
-/* components */
-import { Header } from '@/components/Header';
-
-/* lib */
+/* lib ,components */
 import { Hydrate, QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import { DefaultSeo } from 'next-seo';
+import { RecoilRoot } from 'recoil';
+import { Header } from '@/components/Header';
+import { GlobalStyle } from '../globalStyle';
 import SEO from '../next-seo.config';
 
 /* style */
-import { GlobalStyle } from '../globalStyle';
 import 'antd/dist/antd.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -23,7 +23,9 @@ function MyApp({ Component, pageProps }: AppProps) {
         <GlobalStyle />
         <DefaultSeo {...SEO} />
         <Header />
-        <Component {...pageProps} />
+        <RecoilRoot>
+          <Component {...pageProps} />
+        </RecoilRoot>
       </Hydrate>
       <ReactQueryDevtools />
     </QueryClientProvider>

--- a/apps/nextjs-coinone-app/src/Interface/Register.ts
+++ b/apps/nextjs-coinone-app/src/Interface/Register.ts
@@ -1,7 +1,3 @@
-export interface IProps {
-  setTitle: (value: string) => void;
-}
-
 export interface IRegisterList {
   name: string;
   label: string;

--- a/apps/nextjs-coinone-app/src/components/Header/index.tsx
+++ b/apps/nextjs-coinone-app/src/components/Header/index.tsx
@@ -1,7 +1,7 @@
 /* next */
-import type { FC } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import type { FC } from 'react';
 
 /* codes */
 import { HEADER_MENU } from '../../../constants/codes';

--- a/apps/nextjs-coinone-app/src/containers/Main/MainCarousel.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/MainCarousel.tsx
@@ -1,12 +1,12 @@
+/* lib */
+import { Carousel } from 'antd';
+
 /* next */
-import type { FC } from 'react';
 import Image from 'next/image';
+import type { FC } from 'react';
 
 /* codes */
 import { MAIN_CAROUSEL } from '../../../constants/codes';
-
-/* lib */
-import { Carousel } from 'antd';
 
 /* style */
 import { cssMainCarouselWrap, cssMainCarouselContent } from './Main.style';

--- a/apps/nextjs-coinone-app/src/containers/Main/MainCarouselText.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/MainCarouselText.tsx
@@ -2,9 +2,6 @@
 import type { FC } from 'react';
 import { useState } from 'react';
 
-/* components */
-import { MainCarousel } from './MainCarousel';
-
 /* codes */
 import { MAIN_CAROUSEL } from '../../../constants/codes';
 
@@ -15,6 +12,9 @@ import {
   cssMainCarouselDown,
   cssMainCarouselList,
 } from './Main.style';
+
+/* components */
+import { MainCarousel } from './MainCarousel';
 
 export const MainCarouselText: FC = () => {
   const [open, setOpen] = useState(false);

--- a/apps/nextjs-coinone-app/src/containers/Main/MainRank.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/MainRank.tsx
@@ -1,19 +1,17 @@
-/* next */
-import type { FC } from 'react';
-import Image from 'next/image';
-
-/* lib */
+/* lib, type */
+import { useCallGetCoin } from '@sb/core-lib/api/hooks/useCallCoin';
+import type { ICoin } from '@sb/core-lib/interface/Coin';
 import { Table, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/lib/table';
 
+/* next */
+import Image from 'next/image';
+import type { FC } from 'react';
+
 /* hooks,components */
-import { useCallGetCoin } from '@sb/core-lib/api/hooks/useCallCoin';
 
 /* style */
 import { cssMainRankTitle, cssMainRankTable } from './Main.style';
-
-/* type */
-import type { ICoin } from '@sb/core-lib/interface/Coin';
 
 const columns: ColumnsType<ICoin> = [
   {

--- a/apps/nextjs-coinone-app/src/containers/Main/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Main/index.tsx
@@ -1,12 +1,12 @@
 /* next */
 import type { FC } from 'react';
 
+/* style */
+import { ContentWrap } from '../../style/common';
+
 /* components */
 import { MainCarouselText } from './MainCarouselText';
 import { MainRank } from './MainRank';
-
-/* style */
-import { ContentWrap } from '../../style/common';
 
 export const Main: FC = () => {
   return (

--- a/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
@@ -1,3 +1,4 @@
+import { CheckOutlined } from '@ant-design/icons';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -72,4 +73,8 @@ export const cssCheckboxWrap = css`
       justify-content: space-between;
     }
   }
+`;
+
+export const CheckIcon = styled(CheckOutlined)<{ allagree: boolean }>`
+  color: ${(props) => (props.allagree ? '#1772f8' : '#000000')};
 `;

--- a/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
@@ -1,4 +1,3 @@
-import { CheckOutlined } from '@ant-design/icons';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -73,8 +72,4 @@ export const cssCheckboxWrap = css`
       justify-content: space-between;
     }
   }
-`;
-
-export const CheckIcon = styled(CheckOutlined)<{ allagree: boolean }>`
-  color: ${(props) => (props.allagree ? '#1772f8' : '#000000')};
 `;

--- a/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register.style.tsx
@@ -62,3 +62,14 @@ export const cssRegisterTitle = css`
   font-size: 24px;
   font-weight: 700;
 `;
+
+export const cssCheckboxWrap = css`
+  .ant-checkbox-wrapper {
+    display: flex;
+    .ant-checkbox + span {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+    }
+  }
+`;

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -16,11 +16,11 @@ import {
 } from '../../../constants/codes';
 
 /* types */
-import type { IProps, IRegisterList } from '../../Interface/Register';
+import type { IRegisterList } from '../../Interface/Register';
 
 /* style */
 import { MaxButton } from '../../style/common';
-const Register01: FC<IProps> = (props) => {
+const Register01: FC = () => {
   const form = Form.useFormInstance();
   const userType = Form.useWatch('user-type', form);
   const [userTypeList, setUserTypeList] = useState<IRegisterList[]>([]);
@@ -37,10 +37,6 @@ const Register01: FC<IProps> = (props) => {
     setUserTypeList(typeArr);
     form.setFieldsValue({ ...clearTypes });
   }, [userType]);
-
-  useEffect(() => {
-    props.setTitle('본인인증을 시작합니다.<br />예상 소요시간은 10분입니다.');
-  }, []);
 
   return (
     <>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register01.tsx
@@ -48,7 +48,7 @@ const Register01: FC<IProps> = (props) => {
         label="유저 이름"
         colon={false}
         name="username"
-        rules={FORM_RULES.usenamerule as Rule[]}
+        rules={FORM_RULES.userNameRule as Rule[]}
       >
         <Input />
       </Form.Item>
@@ -57,7 +57,7 @@ const Register01: FC<IProps> = (props) => {
         name="user-type"
         colon={false}
         label="가입유형"
-        rules={FORM_RULES.defaultrule}
+        rules={FORM_RULES.defaultRule}
       >
         <Radio.Group>
           <Radio.Button value="법인">법인</Radio.Button>
@@ -71,7 +71,7 @@ const Register01: FC<IProps> = (props) => {
             label={type.label}
             name={type.name}
             colon={false}
-            rules={FORM_RULES.defaultrule}
+            rules={FORM_RULES.defaultRule}
             style={{ animation: 'showanimation 450ms ease-in-out' }}
           >
             <Radio.Group>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -1,4 +1,5 @@
 /* next, lib */
+import { CheckOutlined } from '@ant-design/icons';
 import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import { Checkbox, Form, Button } from 'antd';
 import type { FC } from 'react';
@@ -9,7 +10,7 @@ import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 
 /* types, style */
 import { MaxButton, LineBox } from '../../style/common';
-import { CheckIcon, cssCheckboxWrap } from './Register.style';
+import { cssCheckboxWrap } from './Register.style';
 
 const Register02: FC = () => {
   const form = Form.useFormInstance();
@@ -30,7 +31,7 @@ const Register02: FC = () => {
   return (
     <>
       <LineBox onClick={changeAllAgree} allagree={allAgree}>
-        <CheckIcon allagree={allAgree} />
+        <CheckOutlined />
         <b>모든 항목에 동의하기</b>
       </LineBox>
       {REGISTER_AGREE_LIST.map((agree) => (

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -1,6 +1,4 @@
 /* next, lib */
-import { CheckOutlined } from '@ant-design/icons';
-import { css } from '@emotion/react';
 import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import { Checkbox, Form, Button } from 'antd';
 import type { FC } from 'react';
@@ -11,7 +9,7 @@ import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 
 /* types, style */
 import { MaxButton, LineBox } from '../../style/common';
-import { cssCheckboxWrap } from './Register.style';
+import { CheckIcon, cssCheckboxWrap } from './Register.style';
 
 const Register02: FC = () => {
   const form = Form.useFormInstance();
@@ -32,9 +30,7 @@ const Register02: FC = () => {
   return (
     <>
       <LineBox onClick={changeAllAgree} allAgree>
-        <CheckOutlined
-          style={allAgree ? { color: '#1772f8' } : { color: '#000' }}
-        />
+        <CheckIcon allagree={allAgree} />
         <b>모든 항목에 동의하기</b>
       </LineBox>
       {REGISTER_AGREE_LIST.map((agree) => (

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -9,11 +9,10 @@ import { useState, useEffect } from 'react';
 /* constans */
 import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 
-/* style */
+/* types, style */
 import type { IProps } from '../../Interface/Register';
-import { MaxButton, FlexBetweenBox, LineBox } from '../../style/common';
-
-/* types */
+import { MaxButton, LineBox } from '../../style/common';
+import { cssCheckboxWrap } from './Register.style';
 
 const Register02: FC<IProps> = (props) => {
   const form = Form.useFormInstance();
@@ -52,17 +51,11 @@ const Register02: FC<IProps> = (props) => {
           name={agree.name}
           valuePropName="checked"
           rules={agree.name !== 'agree4' ? FORM_RULES.defaultRule : undefined}
-          css={css`
-            label {
-              width: 100%;
-            }
-          `}
+          css={cssCheckboxWrap}
         >
           <Checkbox>
-            <FlexBetweenBox>
-              {agree.label}
-              <u>보기</u>
-            </FlexBetweenBox>
+            {agree.label}
+            <u>보기</u>
           </Checkbox>
         </Form.Item>
       ))}

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -1,20 +1,18 @@
-/* next */
+/* next, lib */
+import { CheckOutlined } from '@ant-design/icons';
+import FORM_RULES from '@sb/core-lib/utils/form-rules';
+import { Checkbox, Form, Button } from 'antd';
 import type { FC } from 'react';
 import { useState, useEffect } from 'react';
 
-/* lib */
-import { Checkbox, Form, Button } from 'antd';
-import { CheckOutlined } from '@ant-design/icons';
-
 /* constans */
-import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 
 /* style */
+import type { IProps } from '../../Interface/Register';
 import { MaxButton, FlexBetweenBox, LineBox } from '../../style/common';
 
 /* types */
-import type { IProps } from '../../Interface/Register';
 
 const Register02: FC<IProps> = (props: IProps) => {
   const [form] = Form.useForm();

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -36,10 +36,7 @@ const Register02: FC<IProps> = (props) => {
 
   return (
     <>
-      <LineBox
-        onClick={changeAllAgree}
-        css={allAgree && { borderColor: '#1772f8' }}
-      >
+      <LineBox onClick={changeAllAgree} allAgree>
         <CheckOutlined
           style={allAgree ? { color: '#1772f8' } : { color: '#000' }}
         />

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -48,7 +48,7 @@ const Register02: FC<IProps> = (props: IProps) => {
           key={agree.name}
           name={agree.name}
           valuePropName="checked"
-          rules={agree.name !== 'agree4' ? FORM_RULES.defaultrule : undefined}
+          rules={agree.name !== 'agree4' ? FORM_RULES.defaultRule : undefined}
         >
           <FlexBetweenBox>
             <Checkbox>{agree.label}</Checkbox>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -4,17 +4,16 @@ import { css } from '@emotion/react';
 import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import { Checkbox, Form, Button } from 'antd';
 import type { FC } from 'react';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 /* constans */
 import { REGISTER_AGREE_LIST } from '../../../constants/codes';
 
 /* types, style */
-import type { IProps } from '../../Interface/Register';
 import { MaxButton, LineBox } from '../../style/common';
 import { cssCheckboxWrap } from './Register.style';
 
-const Register02: FC<IProps> = (props) => {
+const Register02: FC = () => {
   const form = Form.useFormInstance();
   const [allAgree, setAllAgree] = useState(false);
 
@@ -29,10 +28,6 @@ const Register02: FC<IProps> = (props) => {
     );
     form.setFieldsValue({ ...clearTypes });
   };
-
-  useEffect(() => {
-    props.setTitle('약관에 동의해 주세요.');
-  }, []);
 
   return (
     <>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -29,7 +29,7 @@ const Register02: FC = () => {
 
   return (
     <>
-      <LineBox onClick={changeAllAgree} allAgree>
+      <LineBox onClick={changeAllAgree} allagree={allAgree}>
         <CheckIcon allagree={allAgree} />
         <b>모든 항목에 동의하기</b>
       </LineBox>

--- a/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/Register02.tsx
@@ -1,5 +1,6 @@
 /* next, lib */
 import { CheckOutlined } from '@ant-design/icons';
+import { css } from '@emotion/react';
 import FORM_RULES from '@sb/core-lib/utils/form-rules';
 import { Checkbox, Form, Button } from 'antd';
 import type { FC } from 'react';
@@ -14,14 +15,17 @@ import { MaxButton, FlexBetweenBox, LineBox } from '../../style/common';
 
 /* types */
 
-const Register02: FC<IProps> = (props: IProps) => {
-  const [form] = Form.useForm();
+const Register02: FC<IProps> = (props) => {
+  const form = Form.useFormInstance();
   const [allAgree, setAllAgree] = useState(false);
 
   const changeAllAgree = () => {
     setAllAgree(!allAgree);
     const clearTypes = REGISTER_AGREE_LIST.reduce(
-      (acc, current) => ({ ...acc, [current.name]: !allAgree }),
+      (acc, current) => ({
+        ...acc,
+        [current.name]: allAgree ? undefined : true,
+      }),
       {}
     );
     form.setFieldsValue({ ...clearTypes });
@@ -44,16 +48,22 @@ const Register02: FC<IProps> = (props: IProps) => {
       </LineBox>
       {REGISTER_AGREE_LIST.map((agree) => (
         <Form.Item
-          shouldUpdate
           key={agree.name}
           name={agree.name}
           valuePropName="checked"
           rules={agree.name !== 'agree4' ? FORM_RULES.defaultRule : undefined}
+          css={css`
+            label {
+              width: 100%;
+            }
+          `}
         >
-          <FlexBetweenBox>
-            <Checkbox>{agree.label}</Checkbox>
-            <u>보기</u>
-          </FlexBetweenBox>
+          <Checkbox>
+            <FlexBetweenBox>
+              {agree.label}
+              <u>보기</u>
+            </FlexBetweenBox>
+          </Checkbox>
         </Form.Item>
       ))}
       <Form.Item>

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -5,25 +5,39 @@ import type { ValidateErrorEntity } from 'rc-field-form/lib/interface';
 
 /* next */
 import type { FC } from 'react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { registerStep, registerDataObj } from 'states';
 
-/* style */
+/* components , style */
 import { cssRegisterTitle, RegisterContentWrap } from './Register.style';
-
-/* components */
 import Register01 from './Register01';
+import Register02 from './Register02';
 
 const Index: FC = () => {
   const [form] = Form.useForm();
   const [title, setTitle] = useState('');
+  const [step, setStep] = useRecoilState(registerStep);
+  const [registerData, setRegisterData] = useRecoilState(registerDataObj);
 
   const onFinish = (values: FormData) => {
-    console.log('Success:', values);
+    setStep(step + 1);
+    setRegisterData({ ...registerData, ...values });
+    console.log('Success:', { ...registerData, ...values });
   };
 
   const onFinishFailed = (errorInfo: ValidateErrorEntity) => {
     console.log('Failed:', errorInfo);
   };
+
+  const registerComponents = useMemo(() => {
+    switch (step) {
+      case 1:
+        return <Register01 setTitle={(value: string) => setTitle(value)} />;
+      case 2:
+        return <Register02 setTitle={(value: string) => setTitle(value)} />;
+    }
+  }, [step]);
 
   return (
     <RegisterContentWrap>
@@ -38,7 +52,7 @@ const Index: FC = () => {
         onFinishFailed={onFinishFailed}
         autoComplete="off"
       >
-        <Register01 setTitle={(value: string) => setTitle(value)} />
+        {registerComponents}
       </Form>
     </RegisterContentWrap>
   );

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -1,25 +1,27 @@
+/* lib */
+import { Form } from 'antd';
+import type FormData from 'antd/lib/form';
+import type { ValidateErrorEntity } from 'rc-field-form/lib/interface';
+
 /* next */
 import type { FC } from 'react';
 import { useState } from 'react';
 
-/* components */
-import Register01 from './Register01';
-
-/* lib */
-import { Form } from 'antd';
-
 /* style */
 import { cssRegisterTitle, RegisterContentWrap } from './Register.style';
+
+/* components */
+import Register01 from './Register01';
 
 const Index: FC = () => {
   const [form] = Form.useForm();
   const [title, setTitle] = useState('');
 
-  const onFinish = (values: any) => {
+  const onFinish = (values: FormData) => {
     console.log('Success:', values);
   };
 
-  const onFinishFailed = (errorInfo: any) => {
+  const onFinishFailed = (errorInfo: ValidateErrorEntity) => {
     console.log('Failed:', errorInfo);
   };
 

--- a/apps/nextjs-coinone-app/src/containers/Register/index.tsx
+++ b/apps/nextjs-coinone-app/src/containers/Register/index.tsx
@@ -5,9 +5,10 @@ import type { ValidateErrorEntity } from 'rc-field-form/lib/interface';
 
 /* next */
 import type { FC } from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useRecoilState } from 'recoil';
 import { registerStep, registerDataObj } from 'states';
+import { REGISTER_TITLE } from '../../../constants/codes';
 
 /* components , style */
 import { cssRegisterTitle, RegisterContentWrap } from './Register.style';
@@ -16,7 +17,6 @@ import Register02 from './Register02';
 
 const Index: FC = () => {
   const [form] = Form.useForm();
-  const [title, setTitle] = useState('');
   const [step, setStep] = useRecoilState(registerStep);
   const [registerData, setRegisterData] = useRecoilState(registerDataObj);
 
@@ -33,16 +33,20 @@ const Index: FC = () => {
   const registerComponents = useMemo(() => {
     switch (step) {
       case 1:
-        return <Register01 setTitle={(value: string) => setTitle(value)} />;
+        return <Register01 />;
       case 2:
-        return <Register02 setTitle={(value: string) => setTitle(value)} />;
+        return <Register02 />;
     }
   }, [step]);
 
   return (
     <RegisterContentWrap>
       <div css={cssRegisterTitle}>
-        <div dangerouslySetInnerHTML={{ __html: title }}></div>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: REGISTER_TITLE[`step${step}`],
+          }}
+        ></div>
       </div>
       <Form
         form={form}

--- a/apps/nextjs-coinone-app/src/states/atom.ts
+++ b/apps/nextjs-coinone-app/src/states/atom.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+export const registerStep = atom({
+  key: 'registerStep',
+  default: 1,
+});
+
+export const registerDataObj = atom({
+  key: 'registerDataObj',
+  default: {},
+});

--- a/apps/nextjs-coinone-app/src/states/index.ts
+++ b/apps/nextjs-coinone-app/src/states/index.ts
@@ -1,0 +1,1 @@
+export * from './atom';

--- a/apps/nextjs-coinone-app/src/style/common.tsx
+++ b/apps/nextjs-coinone-app/src/style/common.tsx
@@ -38,4 +38,7 @@ export const FlexBetweenBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
+  label {
+    width: 100%;
+  }
 `;

--- a/apps/nextjs-coinone-app/src/style/common.tsx
+++ b/apps/nextjs-coinone-app/src/style/common.tsx
@@ -7,8 +7,8 @@ export const ContentWrap = styled.section`
 `;
 
 /* BOX CONTENT */
-export const LineBox = styled.div<{ allAgree: boolean }>`
-  border-color: ${(props) => (props.allAgree ? '#1772f8' : '#e4e5e8')};
+export const LineBox = styled.div<{ allagree: boolean }>`
+  color: ${(props) => (props.allagree ? '#1772f8' : '#000000')};
   border: 1px solid;
   border-radius: 8px;
   transition: border-color 0.25s;

--- a/apps/nextjs-coinone-app/src/style/common.tsx
+++ b/apps/nextjs-coinone-app/src/style/common.tsx
@@ -7,7 +7,7 @@ export const ContentWrap = styled.section`
 `;
 
 /* BOX CONTENT */
-export const LineBox = styled.div<{ allagree: boolean }>`
+export const LineBox = styled.div<{ allagree: boolean | undefined }>`
   color: ${(props) => (props.allagree ? '#1772f8' : '#000000')};
   border: 1px solid;
   border-radius: 8px;
@@ -20,6 +20,10 @@ export const LineBox = styled.div<{ allagree: boolean }>`
   margin-bottom: 32px;
   gap: 10px;
   cursor: pointer;
+  &,
+  & .anticon-check {
+    color: ${(props) => (props.allagree ? '#1772f8' : '#000000')};
+  }
 `;
 
 /* BUTTON */

--- a/apps/nextjs-coinone-app/src/style/common.tsx
+++ b/apps/nextjs-coinone-app/src/style/common.tsx
@@ -7,8 +7,9 @@ export const ContentWrap = styled.section`
 `;
 
 /* BOX CONTENT */
-export const LineBox = styled.div`
-  border: 1px solid #e4e5e8;
+export const LineBox = styled.div<{ allAgree: boolean }>`
+  border-color: ${(props) => (props.allAgree ? '#1772f8' : '#e4e5e8')};
+  border: 1px solid;
   border-radius: 8px;
   transition: border-color 0.25s;
   display: flex;

--- a/packages/core-lib/src/utils/form-rules.ts
+++ b/packages/core-lib/src/utils/form-rules.ts
@@ -8,13 +8,13 @@ interface Irule {
 }
 
 export default {
-  defaultrule: [
+  defaultRule: [
     {
       required: true,
       message: '필수값입니다.',
     },
   ],
-  usenamerule: [
+  userNameRule: [
     {
       required: true,
       message: '유저 이름은 필수값입니다. 2자 이상 입력해주세요',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3528,6 +3528,7 @@ __metadata:
     react: 18.2.0
     react-dom: 18.2.0
     react-query: 3.39.1
+    recoil: 0.7.4
     typescript: 4.7.3
   languageName: unknown
   linkType: soft
@@ -9317,6 +9318,22 @@ __metadata:
     react-native:
       optional: true
   checksum: 6f48077eea4da8a4b0434eb9567210b74d603086bf5760810719bb12cc74d31b93291e7b80d26caa1e3b7e8cf3ec5fc44308fae8be22228cbcc64c78b048751e
+  languageName: node
+  linkType: hard
+
+"recoil@npm:0.7.4":
+  version: 0.7.4
+  resolution: "recoil@npm:0.7.4"
+  dependencies:
+    hamt_plus: 1.0.2
+  peerDependencies:
+    react: ">=16.13.1"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 797b97ee74b2fbbb8e4dda8a951b13569d45a3440cfc05e870056255ff22c73aa816de70d66168a5b9ebe16c14d262777947dd752c8cb9559ef8ae3fbb586472
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- recoil사용하여 회원가입 과정 구현했습니다. (2개)
- registerStep로 페이지 step 카운트, registerDataObj로 페이지 이동시 값 다 저장했습니다.
- 하위 페이지 렌더될떄마다 이전 페이지에서 기존에 작성한 내역들이 삭제되어 recoil에 이동시마다 내역 쌓는것으로 값 등록했습니다.